### PR TITLE
Reproduce issue with turbo_refreshes_with

### DIFF
--- a/app/components/layouts/root.rb
+++ b/app/components/layouts/root.rb
@@ -30,6 +30,9 @@ module Components
             # stylesheet_link_tag :app, data_turbo_track: :reload
             javascript_include_tag :application, data_turbo_track: :reload, type: :module
             stylesheet_link_tag :application, data_turbo_track: :reload
+            turbo_refreshes_with(method: :morph, scroll: :preserve)
+            # meta name: "turbo-refresh-method", content: "morph"
+            # meta name: "turbo-refresh-scroll", content: "preserve"
           end
 
           body(data_controller: "ruby-ui--theme-toggle") do


### PR DESCRIPTION
```ruby
module Components
  module Layouts
    class Root < Base
      include Phlex::Rails::Layout

      private

      def view_template(&)
        doctype

        html(class: "dark") do
          head do
            # this doesn't work
            turbo_refreshes_with(method: :morph, scroll: :preserve) 

            # adding both of these work.
            meta name: "turbo-refresh-method", content: "morph"
            meta name: "turbo-refresh-scroll", content: "preserve"
          end
        end
      end
    end
  end
end
```